### PR TITLE
Have Fulcio hide email addresses.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
+	github.com/bwesterb/go-ristretto v1.2.3 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
+github.com/bwesterb/go-ristretto v1.2.3 h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw=
+github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=

--- a/pkg/pedersen/pedersen.go
+++ b/pkg/pedersen/pedersen.go
@@ -1,0 +1,115 @@
+package pedersen
+
+import (
+	"github.com/bwesterb/go-ristretto"
+)
+
+// import "crypto/rand"
+
+type Parameters struct {
+	g ristretto.Point
+	h ristretto.Point
+}
+
+func Setup(buf []byte) Parameters {
+	var g ristretto.Point
+	var h ristretto.Point
+	g.DeriveDalek(buf[:len(buf)/2])
+	h.DeriveDalek(buf[len(buf)/2:])
+	return Parameters{g, h}
+}
+
+func GetInsecureParameters() Parameters {
+	return Setup([]byte("this is a random string"))
+}
+
+type Message struct {
+	m ristretto.Scalar
+}
+
+func newMessageFromData(buf []byte) Message {
+	var m ristretto.Scalar
+	m.Derive(buf)
+	return Message{m}
+}
+
+type BlindingFactor struct {
+	r ristretto.Scalar
+}
+
+func (r BlindingFactor) Bytes() []byte {
+	return r.r.Bytes()
+}
+
+func BlindingFactorFromBytes(buf *[32]byte) BlindingFactor {
+	var r ristretto.Scalar
+	r.SetBytes(buf)
+	return BlindingFactor{r}
+}
+
+func newBlindingFactorFromData(buf []byte) BlindingFactor {
+	var r ristretto.Scalar
+	r.Derive(buf)
+	return BlindingFactor{r}
+}
+
+func randBlindingFactor() BlindingFactor {
+	var r ristretto.Scalar
+	r.Rand()
+	return BlindingFactor{r}
+}
+
+func (r *BlindingFactor) Equals(r2 *BlindingFactor) bool {
+	return r.r.Equals(&r2.r)
+}
+
+type Commitment struct {
+	c ristretto.Point
+}
+
+func (c Commitment) Bytes() []byte {
+	return c.c.Bytes()
+}
+
+func (c *Commitment) Equals(c2 *Commitment) bool {
+	return c.c.Equals(&c2.c)
+}
+
+func CommitmentFromBytes(buf *[32]byte) Commitment {
+	var c ristretto.Point
+	if !c.SetBytes(buf) {
+		panic("invalid point") // TODO: this should return an error
+	}
+	return Commitment{c}
+}
+
+func (p Parameters) commit(data []byte, m Message, r BlindingFactor) Commitment {
+	var g ristretto.Point
+	var h ristretto.Point
+
+	g.ScalarMult(&p.g, &m.m)
+	h.ScalarMult(&p.h, &r.r)
+	g.Add(&g, &h)
+
+	return Commitment{g}
+}
+
+func (p Parameters) Commit(data []byte) (Commitment, BlindingFactor) {
+	m := newMessageFromData(data)
+	r := randBlindingFactor()
+	comm := p.commit(data, m, r)
+	return comm, r
+}
+
+func (p Parameters) CommitWithRandomness(data []byte, rand []byte) (Commitment, BlindingFactor) {
+	m := newMessageFromData(data)
+	r := newBlindingFactorFromData(rand)
+	comm := p.commit(data, m, r)
+	return comm, r
+}
+
+func (p Parameters) Verify(data []byte, c Commitment, r BlindingFactor) bool {
+	m := newMessageFromData(data)
+	c2 := p.commit(data, m, r)
+	return c.Equals(&c2)
+}

--- a/pkg/pedersen/pedersen_test.go
+++ b/pkg/pedersen/pedersen_test.go
@@ -1,0 +1,123 @@
+package pedersen
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+)
+
+type randomnessSource struct {
+	reader    io.Reader
+	chunkSize int
+	chunks    int
+}
+
+func newRandomnessSource(rand []byte, chunks int) (*randomnessSource, error) {
+	if len(rand) < chunks {
+		return nil, fmt.Errorf("not enough data")
+	}
+	reader := bytes.NewReader(rand)
+	chunkSize := len(rand) / chunks
+	source := randomnessSource{reader, chunkSize, chunks}
+	return &source, nil
+}
+
+func (r *randomnessSource) Chunk() []byte {
+	if r.chunks <= 0 {
+		panic("out of randomness")
+	}
+	r.chunks -= 1
+
+	chunk := make([]byte, r.chunkSize)
+	r.reader.Read(chunk)
+	return chunk
+}
+
+func FuzzCommitmentVerifies(f *testing.F) {
+	f.Add([]byte("<randomness>"), []byte("foo"))
+	f.Fuzz(func(t *testing.T, randData []byte, data []byte) {
+		rand, err := newRandomnessSource(randData, 2)
+		if err != nil {
+			t.Skip(err)
+		}
+
+		p := Setup(rand.Chunk())
+		comm, r := p.CommitWithRandomness(data, rand.Chunk())
+		if !p.Verify(data, comm, r) {
+			t.Error("didn't verify")
+		}
+	})
+
+}
+
+func FuzzCommitmentIncorrectDataFails(f *testing.F) {
+	f.Add([]byte("<randomness>"), []byte("foo"), []byte("bar"))
+	f.Fuzz(func(t *testing.T, randData []byte, data1 []byte, data2 []byte) {
+		if bytes.Equal(data1, data2) {
+			t.Skip("data should not be equal")
+		}
+
+		rand, err := newRandomnessSource(randData, 2)
+		if err != nil {
+			t.Skip(err)
+		}
+
+		p := Setup(rand.Chunk())
+
+		comm, r := p.CommitWithRandomness(data1, rand.Chunk())
+		if p.Verify(data2, comm, r) {
+			t.Error("data2 should not verify with commitment to data1")
+		}
+	})
+}
+
+func FuzzCommitmentIncorrectBlindingFactorFails(f *testing.F) {
+	f.Add([]byte("<randomness>"), []byte("foo"))
+	f.Fuzz(func(t *testing.T, randData []byte, data []byte) {
+		rand, err := newRandomnessSource(randData, 3)
+		if err != nil {
+			t.Skip(err)
+		}
+
+		p := Setup(rand.Chunk())
+
+		comm1, r1 := p.CommitWithRandomness(data, rand.Chunk())
+		comm2, r2 := p.CommitWithRandomness(data, rand.Chunk())
+		if r1 == r2 {
+			if comm1 != comm2 {
+				t.Error("same blinding factor should have same commitment!")
+			}
+			t.Skip("same blinding factor")
+		}
+		if p.Verify(data, comm1, r2) || p.Verify(data, comm2, r1) {
+			t.Error("commitments should only verify with their blinding factor")
+		}
+	})
+}
+
+func FuzzCommitmentBytesRoundtrip(f *testing.F) {
+	f.Add([]byte("<randomness>"), []byte("foo"))
+	f.Fuzz(func(t *testing.T, randData []byte, data []byte) {
+		rand, err := newRandomnessSource(randData, 2)
+		if err != nil {
+			t.Skip(err)
+		}
+
+		p := Setup(rand.Chunk())
+		comm, r := p.CommitWithRandomness(data, rand.Chunk())
+
+		bytes := [32]byte(comm.Bytes())
+		comm2 := CommitmentFromBytes(&bytes)
+		if !comm.Equals(&comm2) {
+			t.Errorf("commitment roundtrip failed: %+v, %+v", comm, comm2)
+		}
+
+		bytes = [32]byte(r.Bytes())
+		r2 := BlindingFactorFromBytes(&bytes)
+		if !r.Equals(&r2) {
+			t.Errorf("blinding factor roundtrip failed: %+v, %+v", r, r2)
+		}
+	})
+
+}


### PR DESCRIPTION
Example:

```
X509v3 Subject Alternative Name: critical
    email:12cc009539fc97e6d648cd279c22dcb992678ba9607c3f7efb7a4e7520425350@pedersen.commitment
```

Instead of:

```
X509v3 Subject Alternative Name: critical
    email:zjn@chainguard.dev
```

To reproduce:

```
go run main.go serve --port 5555 --ca ephemeralca --ct-log-url=""
```

```
$ cosign sign-blob \
    --fulcio-url http://localhost:5555 \
    --insecure-skip-verify \
    --tlog-upload=false \
    --output-certificate crt.pem.b64 \
    --yes \
    /dev/null
$ step certificate inspect <(base64 -d crt.pem.b64)
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 584069820508095263706703199128124022221671342617 (0x664e98b83b8ddfb1225514bb3901d2d42259a219)
    Signature Algorithm: ECDSA-SHA256
        Issuer: C=USA,ST=WA,L=Kirkland,STREET=767 6th St S,POSTALCODE=98033,O=sigstore
        Validity
            Not Before: Apr 30 22:26:55 2023 UTC
            Not After : Apr 30 22:36:55 2023 UTC
        Subject:
        Subject Public Key Info:
            Public Key Algorithm: ECDSA
                Public-Key: (256 bit)
                X:
                    97:cf:a3:98:8e:65:8f:d6:5e:e9:1d:42:1a:b9:63:
                    f0:90:8e:76:c6:a5:78:dd:26:4d:3e:e5:61:68:28:
                    da:c8
                Y:
                    39:11:10:72:6f:95:19:d0:22:55:33:e1:1a:21:5a:
                    ed:29:68:d0:4a:4e:54:1c:b8:69:1e:e5:fb:b4:7b:
                    66:61
                Curve: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature
            X509v3 Extended Key Usage:
                Code Signing
            X509v3 Subject Key Identifier:
                23:A3:A8:C4:2D:55:A4:66:2A:C6:D7:2E:F6:A0:1E:DD:5E:1D:B7:B8
            X509v3 Authority Key Identifier:
                keyid:06:17:BE:9B:28:11:AF:2E:FB:3D:75:BB:53:9E:5D:4C:43:79:0C:A1
            X509v3 Subject Alternative Name: critical
                email:12cc009539fc97e6d648cd279c22dcb992678ba9607c3f7efb7a4e7520425350@pedersen.commitment
            Sigstore OIDC Issuer:
                https://accounts.google.com/
            1.3.6.1.4.1.57264.1.8:
                ..https://accounts.google.com/
    Signature Algorithm: ECDSA-SHA256
         30:46:02:21:00:a1:7d:51:7b:93:da:24:01:a6:8d:fe:2e:d0:
         82:63:d1:7b:d9:42:3a:7b:3b:0f:cf:9e:92:9f:9b:9d:a8:c5:
         1a:02:21:00:c1:d6:d7:e2:33:18:1a:60:2a:d7:4d:a8:c6:ff:
         fe:20:74:0b:34:fd:91🇩🇪49:60:37:ed:65:b6:3a:18:24:e8
```

vs.

```
$ cosign sign-blob \
    --tlog-upload=false \
    --output-certificate /tmp/crt-orig.pem.b64 \
    --yes \
    /dev/null
$ step certificate inspect <(base64 -d crt-orig.pem.b64)
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 657141817025712980495417183601715402816661581441 (0x731b421a01cdda174cd5fcfabab84bbd3d916e81)
    Signature Algorithm: ECDSA-SHA384
        Issuer: O=sigstore.dev,CN=sigstore-intermediate
        Validity
            Not Before: Jun 22 16:37:03 2023 UTC
            Not After : Jun 22 16:47:03 2023 UTC
        Subject:
        Subject Public Key Info:
            Public Key Algorithm: ECDSA
                Public-Key: (256 bit)
                X:
                    b0:99:c2:d2:40:7b:be:d5:30:09:6b:6a:b5:84:c1:
                    63:0e:c1:f5:11:e4:db:e5:df:6c:98:19:9b:9e:11:
                    67:8d
                Y:
                    9c:16:3d:bd:85:d0:dd:d3:85:7a:f0:a8:80:57:06:
                    91:d1:4b:7d:65:bd:2e:41:84:b8:2e:c6:e9:6f:c5:
                    2b:bc
                Curve: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature
            X509v3 Extended Key Usage:
                Code Signing
            X509v3 Subject Key Identifier:
                D8:22:5C:FD:57:0A:2C:8A:A1:FA:57:F1:BC:26:4C:5E:1C:10:F3:C8
            X509v3 Authority Key Identifier:
                keyid:DF:D3:E9:CF:56:24:11:96:F9:A8:D8:E9:28:55:A2:C6:2E:18:64:3F
            X509v3 Subject Alternative Name: critical
                email:zjn@chainguard.dev
            Sigstore OIDC Issuer:
                https://accounts.google.com/
            1.3.6.1.4.1.57264.1.8:
                ..https://accounts.google.com/
            RFC6962 Certificate Transparency SCT:
                SCT [0]:
                    Version: V1 (0x0)
                    LogID: 3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4=
                    Timestamp: Jun 22 16:37:03.560 2023 UTC
                    Signature Algorithm: SHA256-ECDSA
                      30:45:02:20:51:82:3d:a0:98:01:1c:5e:2c:23:48:f3:01:14:
                      80:3c:f2:b6:56:83:21:85:25:e0🇩🇪01:7d:c9:a0:7f:fb:af:
                      02:21:00:8a:16:92:40:d7:0f:31:24:c7:8b:3a:38:b7:30:2d:
                      1d:eb:9a:6a:34:f8:85:6e:6c:fc:fe:31:9f:4d:bb:88:ef
    Signature Algorithm: ECDSA-SHA384
         30:65:02:30:03:3b:29:f0:72:d1:8a:c9:d3:b6:07:09:48:75:
         c2:a8:a6:aa:ef:3d:6f:0b:f4:c7:d4:38:89:05:bd:98:4e:af:
         2a:66:14:01:ea:fe:2d:3f:2c:1a:a1:90:a5:0f:3c:4a:02:31:
         00:a3:fe:7d:a2:9c:30:48:59:6e:d4:c8:82:29:df:5b:c4:2d:
         15:94:a3:4b:f1:8d:54:1c:c6:41:41:30:33:7b:f4:54:c5:85:
         3c:34:ff:8e:7a:29:fa:50💿39:a5:15:ae
```